### PR TITLE
fix benchmark output

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -684,7 +684,7 @@ func BenchmarkAll(b *testing.B) {
 		writeTPS := float64(writeOps*writeSize) / writeTime.Seconds()
 		readTPS := float64(readOps*writeSize) / readTime.Seconds()
 
-		fmt.Fprintf(&results, "%9d | %11s | %12s | %14.2f | %14.2f\n",
+		fmt.Fprintf(&results, "%10d | %12s | %13s | %15.2f | %14.2f\n",
 			writeSize, batchSize, dbSize, writeTPS, readTPS)
 	}
 


### PR DESCRIPTION
Before:
```
        Transaction Processing Speed Summary:
        =====================================
        Batch Size |  Batch Data  |    DB Size    |    Write TPS    |    Read TPS     
        -----------|--------------|---------------|-----------------|----------------
               24 |     24.0 KB |      47.5 MB |      116263.82 |      176105.92
              122 |    122.0 KB |      84.2 MB |      123075.39 |      172681.46
              244 |    244.0 KB |     122.4 MB |      125811.63 |      170775.83
              488 |    488.0 KB |     165.6 MB |      130160.82 |      172735.46
```

After:
```
        Transaction Processing Speed Summary:
        =====================================
        Batch Size |  Batch Data  |    DB Size    |    Write TPS    |    Read TPS     
        -----------|--------------|---------------|-----------------|----------------
                16 |      16.0 KB |       47.3 MB |       115645.78 |      171146.68
                81 |      81.0 KB |       83.6 MB |       118186.11 |      175158.33
               163 |     163.0 KB |      122.5 MB |       124311.97 |      157030.25
               326 |     326.0 KB |      162.2 MB |       128566.90 |      177299.77
```